### PR TITLE
Bump whatsapp-web.js from 1.19.5 to 1.20.0-alpha.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "true-di": "^3.0.0",
         "ts-command-line-args": "^2.3.1",
         "typescript-logger": "^5.0.1",
-        "whatsapp-web.js": "1.19.5",
+        "whatsapp-web.js": "1.20.0-alpha.0",
         "winston": "^3.8.2"
       },
       "devDependencies": {
@@ -9368,9 +9368,9 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/whatsapp-web.js": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/whatsapp-web.js/-/whatsapp-web.js-1.19.5.tgz",
-      "integrity": "sha512-tavnhcQEbmlTzzLDVqqxIjWllsOwM0/5hhASame3bKEUT7Wk+q0z8g3cYMk43Eqdip1bK1rqUvwzzD3lDNfwCA==",
+      "version": "1.20.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/whatsapp-web.js/-/whatsapp-web.js-1.20.0-alpha.0.tgz",
+      "integrity": "sha512-QnTTVlh8ti7VRQAa5xbCdjHIcNl4wcg4jM6cCpN0UFfOv5PrxaUgIdrU+7KkCO87W+lF8LfP5LUzTefRkjT35g==",
       "dependencies": {
         "@pedroslopez/moduleraid": "^5.0.2",
         "fluent-ffmpeg": "^2.1.2",
@@ -15891,9 +15891,9 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "whatsapp-web.js": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/whatsapp-web.js/-/whatsapp-web.js-1.19.5.tgz",
-      "integrity": "sha512-tavnhcQEbmlTzzLDVqqxIjWllsOwM0/5hhASame3bKEUT7Wk+q0z8g3cYMk43Eqdip1bK1rqUvwzzD3lDNfwCA==",
+      "version": "1.20.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/whatsapp-web.js/-/whatsapp-web.js-1.20.0-alpha.0.tgz",
+      "integrity": "sha512-QnTTVlh8ti7VRQAa5xbCdjHIcNl4wcg4jM6cCpN0UFfOv5PrxaUgIdrU+7KkCO87W+lF8LfP5LUzTefRkjT35g==",
       "requires": {
         "@pedroslopez/moduleraid": "^5.0.2",
         "archiver": "^5.3.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "true-di": "^3.0.0",
     "ts-command-line-args": "^2.3.1",
     "typescript-logger": "^5.0.1",
-    "whatsapp-web.js": "1.19.5",
+    "whatsapp-web.js": "1.20.0-alpha.0",
     "winston": "^3.8.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull request updates the `whatsapp-web.js` package to the latest version `1.20.0-alpha.0`. This update addresses the issue with the `TypeError: data.id.id.substring is not a function` error that occurs in the `Message._patch` function.

### Changes Made

- Updated the `whatsapp-web.js` package to version `1.20.0-alpha.0`.
- Tested the updated package to confirm that the `TypeError` error is resolved.
- Verified the compatibility of the updated package with the existing codebase and functionality.

### Checklist

- [x] Updated the `whatsapp-web.js` package to version `1.20.0-alpha.0`.
- [x] Tested the updated package to confirm the resolution of the `TypeError` error.
- [x] Ensured the compatibility of the updated package with the existing codebase.
