### PR TITLE
Add message reaction event

### DIFF
--- a/src/Libs/HomeAssistant.ts
+++ b/src/Libs/HomeAssistant.ts
@@ -1,7 +1,7 @@
 import { IEventPublisher } from './../Services/HomeAssistant/EventPublisher'
 import { IEventBus } from './EventBus'
 import { ILogger } from './Logger'
-import { IMessageAckEvent, IMessageEvent, IStateChangeEvent, IMessageRevokeForEveryoneEvent, IMessageRevokeForMeEvent, IGroupNotificationEvent, ICallEvent } from './Whatsapp'
+import { IMessageAckEvent, IMessageEvent, IStateChangeEvent, IMessageRevokeForEveryoneEvent, IMessageRevokeForMeEvent, IGroupNotificationEvent, ICallEvent, IMessageReactionEvent } from './Whatsapp'
 
 export interface IHomeAssistant {
     start: () => void
@@ -29,6 +29,7 @@ export default class HomeAssistant implements IHomeAssistant {
         this.eventBus.register('whatsapp.message', this.onMessage.bind(this))
         this.eventBus.register('whatsapp.message.create', this.onCreatedMessage.bind(this))
         this.eventBus.register('whatsapp.message.ack', this.onMessageAck.bind(this))
+        this.eventBus.register('whatsapp.message.reaction', this.onMessageReaction.bind(this))
         this.eventBus.register('whatsapp.message.revoke_for_everyone', this.onMessageRevokeForEveryone.bind(this))
         this.eventBus.register('whatsapp.message.revoke_for_me', this.onMessageRevokeForMe.bind(this))
         this.eventBus.register('whatsapp.group.join', this.onGroupJoin.bind(this))
@@ -66,6 +67,11 @@ export default class HomeAssistant implements IHomeAssistant {
 
         this.logger.debug('onMessageAck', event)
         await this.sendToHomeAssistant('message_ack', event)
+    }
+
+    private async onMessageReaction (data: IMessageReactionEvent): Promise<void> {
+        this.logger.debug('onMessageReaction', data.reaction)
+        await this.sendToHomeAssistant('message_reaction', data.reaction)
     }
 
     private async onMessageRevokeForEveryone (data: IMessageRevokeForEveryoneEvent): Promise<void> {

--- a/src/Libs/WebSocket.ts
+++ b/src/Libs/WebSocket.ts
@@ -2,7 +2,7 @@ import { Server, Socket } from 'socket.io'
 import http from 'http'
 import { ILogger } from './Logger'
 import { IEventBus } from './EventBus'
-import { IQRCodeEvent, IMessageEvent, IMessageAckEvent, IStateChangeEvent, IMessageRevokeForEveryoneEvent, IMessageRevokeForMeEvent, IGroupNotificationEvent, ICallEvent, IAuthFailureEvent } from './Whatsapp'
+import { IQRCodeEvent, IMessageEvent, IMessageAckEvent, IStateChangeEvent, IMessageRevokeForEveryoneEvent, IMessageRevokeForMeEvent, IGroupNotificationEvent, ICallEvent, IAuthFailureEvent, IMessageReactionEvent } from './Whatsapp'
 import qrCode from 'qrcode'
 
 export interface IWebSocket {
@@ -27,6 +27,7 @@ export default class WebSocket implements IWebSocket {
         this.eventBus.register('whatsapp.message', this.onMessage.bind(this))
         this.eventBus.register('whatsapp.message.create', this.onCreatedMessage.bind(this))
         this.eventBus.register('whatsapp.message.ack', this.onMessageAck.bind(this))
+        this.eventBus.register('whatsapp.message.reaction', this.onMessageReaction.bind(this))
         this.eventBus.register('whatsapp.revoke_for_everyone', this.onMessageRevokeForEveryone.bind(this))
         this.eventBus.register('whatsapp.revoke_for_me', this.onMessageRevokeForMe.bind(this))
         this.eventBus.register('whatsapp.group.join', this.onGroupJoin.bind(this))
@@ -75,6 +76,11 @@ export default class WebSocket implements IWebSocket {
             ack: data.ack
         })
         this.logger.debug('New message ack')
+    }
+
+    private onMessageReaction (data: IMessageReactionEvent): void {
+        this.io.emit('message.reaction', data.reaction)
+        this.logger.debug('New message reaction')
     }
 
     private onMessageRevokeForEveryone (data: IMessageRevokeForEveryoneEvent): void {

--- a/src/Libs/Whatsapp.ts
+++ b/src/Libs/Whatsapp.ts
@@ -27,6 +27,10 @@ export interface IMessageAckEvent {
     ack: WAWebJS.MessageAck
 }
 
+export interface IMessageReactionEvent {
+    reaction: WAWebJS.Reaction
+}
+
 export interface IMessageRevokeForEveryoneEvent {
     message: WAWebJS.Message
     revokedMessage: WAWebJS.Message
@@ -68,6 +72,7 @@ export default class Whatsapp implements IWhatsapp {
         this.client.on('message', this.onMessage.bind(this))
         this.client.on('message_create', this.onMessageCreate.bind(this))
         this.client.on('message_ack', this.onMessageAck.bind(this))
+        this.client.on('message_reaction', this.onMessageReaction.bind(this))
         this.client.on('message_revoke_everyone', this.onMessageRevokeForEveryone.bind(this))
         this.client.on('message_revoke_me', this.onMessageRevokeForMe.bind(this))
         this.client.on('group_join', this.onGroupJoin.bind(this))
@@ -172,6 +177,16 @@ export default class Whatsapp implements IWhatsapp {
         }
 
         this.eventBus.dispatch('whatsapp.message.ack', event)
+    }
+
+    private onMessageReaction (reaction: WAWebJS.Reaction): void {
+        this.logger.debug('Message reaction', reaction)
+
+        const event: IMessageReactionEvent = {
+            reaction
+        }
+
+        this.eventBus.dispatch('whatsapp.message.reaction', event)
     }
 
     private onMessageRevokeForEveryone (message: WAWebJS.Message, revokedMessage: WAWebJS.Message): void {

--- a/tests/Libs/WebSocket.test.ts
+++ b/tests/Libs/WebSocket.test.ts
@@ -45,6 +45,7 @@ describe('WebSocket tests', () => {
         expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.message', expect.any(Function))
         expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.message.create', expect.any(Function))
         expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.message.ack', expect.any(Function))
+        expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.message.reaction', expect.any(Function))
         expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.revoke_for_everyone', expect.any(Function))
         expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.revoke_for_me', expect.any(Function))
         expect(mockEventBus.register).toHaveBeenCalledWith('whatsapp.group.join', expect.any(Function))
@@ -146,6 +147,27 @@ describe('WebSocket tests', () => {
         const onMessageAck = findCallback(mockEventBus.register.mock, 'whatsapp.message.ack')
         onMessageAck(mockMessage)
         expect(mockEmit).toHaveBeenCalledWith('message.ack', { message: mockMessage.message.rawData, ack: mockMessage.ack })
+    })
+
+    it('onMessageReaction', async () => {
+        mockStartWebSocket()
+
+        const event = {
+            reaction: {
+                id: {
+                    fromMe: false,
+                    remote: '554199999999@c.us'
+                },
+                reaction: '👍',
+                senderId: 'ID',
+                ack: -1
+            }
+        }
+
+        const onMessageReaction = findCallback(mockEventBus.register.mock, 'whatsapp.message.reaction')
+        onMessageReaction(event)
+        expect(mockEmit).toHaveBeenCalledWith('message.reaction', event.reaction)
+        expect(mockLogger.debug).toHaveBeenCalledWith('New message reaction')
     })
 
     it('onRevokeForEveryone', async () => {

--- a/tests/Libs/Whatsapp.test.ts
+++ b/tests/Libs/Whatsapp.test.ts
@@ -3,7 +3,7 @@ import mockLogger from '../stubs/Logger'
 import mockEventBus from '../stubs/EventBus'
 import Whatsapp from '../../src/Libs/Whatsapp'
 import { Client } from 'whatsapp-web.js'
-import { findCallback } from '../utils/Utils'
+import { findCallback, findAsyncCallback } from '../utils/Utils'
 
 // mock resolve a promise
 const mockInitialize = jest.fn().mockResolvedValue(true)
@@ -191,7 +191,7 @@ describe('Whatsapp tests', () => {
         const whatsapp = new Whatsapp(new Client({}), mockLogger, mockEventBus)
         await whatsapp.start()
 
-        const onDisconnected = findCallback(mockOn.mock, 'disconnected')
+        const onDisconnected = findAsyncCallback(mockOn.mock, 'disconnected')
         await onDisconnected('reason')
 
         expect(mockLogger.info).toHaveBeenCalledWith('Client is disconnected', 'reason')

--- a/tests/Libs/Whatsapp.test.ts
+++ b/tests/Libs/Whatsapp.test.ts
@@ -192,7 +192,7 @@ describe('Whatsapp tests', () => {
         await whatsapp.start()
 
         const onDisconnected = findCallback(mockOn.mock, 'disconnected')
-        await onDisconnected('reason')
+        onDisconnected('reason')
 
         expect(mockLogger.info).toHaveBeenCalledWith('Client is disconnected', 'reason')
         expect(mockEventBus.dispatch).toHaveBeenCalledWith('whatsapp.disconnected', { state: 'reason' })

--- a/tests/Libs/Whatsapp.test.ts
+++ b/tests/Libs/Whatsapp.test.ts
@@ -34,6 +34,29 @@ const mockMessage = {
     ]
 }
 
+const mockMessageReaction = {
+    id: {
+        fromMe: false,
+        remote: '554199999999@c.us',
+        id: '1',
+        _serialized: 'false_1_1'
+    },
+
+    orphan: 1,
+    orphanReason: 'reason',
+    timestamp: 1591482682,
+    reaction: '👍',
+    read: false,
+    msgId: {
+        fromMe: false,
+        remote: '554199999999@c.us',
+        id: '1',
+        _serialized: 'false_1_1'
+    },
+    senderId: 'ID',
+    ack: -1
+}
+
 const mockGroupNotification = {
     id: {
         fromMe: false,
@@ -101,6 +124,7 @@ describe('Whatsapp tests', () => {
         expect(mockOn).toHaveBeenCalledWith('message', expect.any(Function))
         expect(mockOn).toHaveBeenCalledWith('message_create', expect.any(Function))
         expect(mockOn).toHaveBeenCalledWith('message_ack', expect.any(Function))
+        expect(mockOn).toHaveBeenCalledWith('message_reaction', expect.any(Function))
         expect(mockOn).toHaveBeenCalledWith('message_revoke_everyone', expect.any(Function))
         expect(mockOn).toHaveBeenCalledWith('message_revoke_me', expect.any(Function))
         expect(mockOn).toHaveBeenCalledWith('group_join', expect.any(Function))
@@ -249,6 +273,19 @@ describe('Whatsapp tests', () => {
         expect(mockEventBus.dispatch).toHaveBeenCalledWith('whatsapp.message.ack', {
             message: mockMessage,
             ack: 1
+        })
+    })
+
+    it('onMessageReaction', async () => {
+        const whatsapp = new Whatsapp(new Client({}), mockLogger, mockEventBus)
+        await whatsapp.start()
+
+        const onMessageReaction = findCallback(mockOn.mock, 'message_reaction')
+
+        onMessageReaction(mockMessageReaction, 'reaction')
+        expect(mockLogger.debug).toHaveBeenCalledWith('Message reaction', mockMessageReaction)
+        expect(mockEventBus.dispatch).toHaveBeenCalledWith('whatsapp.message.reaction', {
+            reaction: mockMessageReaction
         })
     })
 

--- a/tests/Libs/Whatsapp.test.ts
+++ b/tests/Libs/Whatsapp.test.ts
@@ -192,7 +192,7 @@ describe('Whatsapp tests', () => {
         await whatsapp.start()
 
         const onDisconnected = findCallback(mockOn.mock, 'disconnected')
-        onDisconnected('reason')
+        await onDisconnected('reason')
 
         expect(mockLogger.info).toHaveBeenCalledWith('Client is disconnected', 'reason')
         expect(mockEventBus.dispatch).toHaveBeenCalledWith('whatsapp.disconnected', { state: 'reason' })

--- a/tests/utils/Utils.ts
+++ b/tests/utils/Utils.ts
@@ -1,4 +1,4 @@
 
-export function findCallback (mock: any, name: string): (...args: any[]) => void {
+export function findCallback (mock: any, name: string): (...args: any[]) => void | Promise<void> {
     return mock.calls.find((call: any) => call[0] === name)[1]
 }

--- a/tests/utils/Utils.ts
+++ b/tests/utils/Utils.ts
@@ -1,4 +1,8 @@
 
-export function findCallback (mock: any, name: string): (...args: any[]) => void | Promise<void> {
+export function findCallback (mock: any, name: string): (...args: any[]) => void {
+    return mock.calls.find((call: any) => call[0] === name)[1]
+}
+
+export function findAsyncCallback (mock: any, name: string): (...args: any[]) => Promise<void> {
     return mock.calls.find((call: any) => call[0] === name)[1]
 }


### PR DESCRIPTION
This pull request adds support for the `whatsapp.message.reaction` event in the `Whatsapp` module.

### Changes Made

- Added an event listener for the `message_reaction` event in the `Whatsapp.start` method.
- Implemented the `onMessageReaction` method to handle the `message_reaction` event.
- Created the `IMessageReactionEvent` interface to define the structure of the event payload.
- Dispatched the `whatsapp.message.reaction` event using the `eventBus`.
- The event payload includes the following properties:
  - `id`: An object with information about the message, including the sender, message ID, and serialization details.
  - `orphan`: A number representing the orphan status of the reaction.
  - `orphanReason`: A string describing the reason for the orphan status.
  - `timestamp`: A Unix timestamp indicating when the reaction occurred.
  - `reaction`: The emoji reaction.
  - `read`: A boolean indicating if the message has been read.
  - `msgId`: An object with information about the message, similar to the `id` property.
  - `senderId`: The ID of the sender.
  - `ack`: An acknowledgment status number.

### Usage

The `whatsapp.message.reaction` event is dispatched when a message reaction is received. Modules such as `HomeAssistant` and `Websockets` listen for this event and emit their respective events based on the reaction.

- The `HomeAssistant` module emits the event: `whatsapp.message.reaction`.
- The `Websockets` module emits the event: `message.reaction`.
