### PR TITLE
Add new endpoint to get a message by ID

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -28,6 +28,7 @@ _A WhatsApp Http API Rest for NodeJS and integrated with Home Assistant_
 
   - [Messages](#messages)
     - [Get Messages](#get-messages)
+    - [Get Message by ID](#get-message-by-id)
     - [Send Message](#send-message)
       - [Send text message](#send-text-message)
       - [Send media message](#send-media-message)
@@ -284,6 +285,42 @@ Response: `200`
   ...
 ]
 ```
+
+### **Get Message by ID**
+`GET` `/api/chats/{id}/messages/{messageId}`
+
+Response: `200`
+```json
+{
+    "id": {
+      "fromMe": true,
+      "remote": "123456789@c.us",
+      "id": "132E527E5E536E",
+      "_serialized": "true_123456789@c.us_132E527E5E536E"
+    },
+    "ack": 3,
+    "hasMedia": false,
+    "body": "Hello",
+    "type": "chat",
+    "timestamp": 1669914773,
+    "from": "123456789@c.us",
+    "to": "987654321@c.us",
+    "deviceType": "web",
+    "isForwarded": false,
+    "forwardingScore": 0,
+    "isStatus": false,
+    "isStarred": false,
+    "fromMe": true,
+    "hasQuotedMsg": false,
+    "vCards": [],
+    "mentionedIds": [],
+    "isGif": false,
+    "isEphemeral": false,
+    "links": []
+  }
+```
+
+
 ### **Send Message**
 You can send a message to a user or a group
 

--- a/src/Services/Message/MessageGetter.ts
+++ b/src/Services/Message/MessageGetter.ts
@@ -10,8 +10,8 @@ export default class MessageGetter implements IMessageGetter {
         private readonly chatFinder: IChatFinder
     ) {}
 
-    public async all (chatId: string, limit?: number): Promise<Message[]> {
+    public async all (chatId: string, limit?: number, _fromMe?: boolean): Promise<Message[]> {
         const chat = await this.chatFinder.find(chatId)
-        return await chat.fetchMessages({ limit: undefined === limit ? 100 : limit })
+        return await chat.fetchMessages({ limit: undefined === limit ? 100 : limit, fromMe: _fromMe })
     }
 }

--- a/src/http/controllers/ChatMessageController.ts
+++ b/src/http/controllers/ChatMessageController.ts
@@ -2,6 +2,7 @@ import { IMessageReact } from './../../Services/Message/MessageReact'
 import { IMessageStar } from './../../Services/Message/MessageStar'
 import { IMessageDeleter } from './../../Services/Message/MessageDeleter'
 import { IMessageGetter } from './../../Services/Message/MessageGetter'
+import { IMessageFinder } from './../../Services/Message/MessageFinder'
 import ChatMessageValidator from '../../http/validators/MessageReactValidator'
 import MessageValidator from '../validators/MessageValidator'
 
@@ -16,6 +17,11 @@ export const index = (request: Request, response: Response, next: Next) =>
     async ({ messageGetter }: { messageGetter: IMessageGetter }) =>
         await messageGetter.all(request.params.id, request.query.limit === undefined ? undefined : Number(request.query.limit))
             .then(messages => response.json(messages), next)
+
+export const show = (request: Request, response: Response, next: Next) =>
+    async ({ messageFinder }: { messageFinder: IMessageFinder }) => 
+        await messageFinder.find(request.params.id, request.params.messageId)
+            .then(message => response.json(message.rawData), next)
 
 export const store = (request: Request, response: Response, next: Next) =>
     async ({ textMessageCreator, mediaUrlMessageCreator }: { textMessageCreator: ITextMessageCreator, mediaUrlMessageCreator: IMediaUrlMessageCreator }) => {

--- a/src/http/controllers/ChatMessageController.ts
+++ b/src/http/controllers/ChatMessageController.ts
@@ -19,7 +19,7 @@ export const index = (request: Request, response: Response, next: Next) =>
             .then(messages => response.json(messages), next)
 
 export const show = (request: Request, response: Response, next: Next) =>
-    async ({ messageFinder }: { messageFinder: IMessageFinder }) => 
+    async ({ messageFinder }: { messageFinder: IMessageFinder }) =>
         await messageFinder.find(request.params.id, request.params.messageId)
             .then(message => response.json(message.rawData), next)
 

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -70,6 +70,10 @@ export default function (context: ContextManager<IServices>): express.Router {
         context.consumer(ChatMessageController.store)
     )
 
+    router.route('/chats/:id/messages/:messageId').get(
+        context.consumer(ChatMessageController.show)
+    )
+
     router.route('/chats/:id/messages/:messageId/star').put(
         context.consumer(ChatMessageController.star)
     )

--- a/tests/http/controllers/ChatMessageController.test.ts
+++ b/tests/http/controllers/ChatMessageController.test.ts
@@ -1,4 +1,4 @@
-import { mockMessage } from './../../stubs/services/Message/MessageFinder'
+import { mockMessage, mockMessageFinder } from './../../stubs/services/Message/MessageFinder'
 import request from 'supertest'
 import testServer from '../../utils/TestWebServer'
 import { MessageMedia } from 'whatsapp-web.js'
@@ -125,6 +125,16 @@ describe('ChatMessageController', () => {
 
         expect(mockTextSender).toBeCalledTimes(1)
         expect(mockTextSender).toBeCalledWith('1234567890@c.us', 'Test', expect.any(Object))
+    })
+
+    it('find message from chat', async () => {
+        mockMessageFinder.find.mockResolvedValue(mockMessage)
+
+        await request(testServer.app)
+            .get('/api/chats/1234567890/messages/12345')
+            .expect(200, JSON.stringify(mockMessage.rawData))
+
+        expect(mockMessageFinder.find).toBeCalledWith('1234567890', '12345')
     })
 
     it('send text message to chat with options', async () => {


### PR DESCRIPTION
This pull request adds a new endpoint to the API for retrieving a message by its ID. The endpoint is a `GET` request to `/api/chats/{id}/messages/{messageId}`.

### Changes Made

- Added a new route handler for the `/api/chats/{id}/messages/{messageId}` endpoint.
- Implemented the logic to retrieve the message by its ID.
- Updated the documentation to include information about the new endpoint, including the request URL, method, and parameters.
- Included example responses in the documentation to illustrate the expected output.

### Usage

To retrieve a message by its ID, make a `GET` request to the following endpoint:

```
/api/chats/{id}/messages/{messageId}
```

Replace `{id}` with the ID of the chat and `{messageId}` with the ID of the message you want to retrieve.

The response will include the details of the message, such as its content, sender, timestamp, and any attachments.